### PR TITLE
FEAT - 패치노트 정보 저장 및 관리 기능 추가

### DIFF
--- a/src/main/java/soup/japopgg/crawlPatchNote/dto/PatchedChampionDTO.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/dto/PatchedChampionDTO.java
@@ -3,6 +3,7 @@ package soup.japopgg.crawlPatchNote.dto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -10,11 +11,13 @@ import java.util.List;
 public class PatchedChampionDTO {
     private String champion;
     private String patchNoteTitle;
+    private LocalDate patchDate;
     private List<PatchedAbilityDTO> patchInfo;
 
-    public PatchedChampionDTO(String champion, String patchNoteTitle, List<PatchedAbilityDTO> patchInfo) {
+    public PatchedChampionDTO(String champion, String patchNoteTitle, LocalDate patchDate, List<PatchedAbilityDTO> patchInfo) {
         this.champion = champion;
         this.patchNoteTitle = patchNoteTitle;
+        this.patchDate = patchDate;
         this.patchInfo = patchInfo;
     }
 }

--- a/src/main/java/soup/japopgg/crawlPatchNote/entity/PatchNote.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/entity/PatchNote.java
@@ -1,0 +1,41 @@
+package soup.japopgg.crawlPatchNote.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name="PatchNote")
+public class PatchNote {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String patchNotePath;
+    @Column(nullable = false)
+    private String patchNoteTitle;
+    @Column(nullable = false)
+    private LocalDate patchDate;
+
+    @Builder
+    public PatchNote(String patchNotePath,
+                     String patchNoteTitle,
+                     LocalDate patchDate){
+        this.patchNotePath=patchNotePath;
+        this.patchNoteTitle=patchNoteTitle;
+        this.patchDate=patchDate;
+    }
+
+    public void updatePatchNote(String patchNotePath,
+                                String patchNoteTitle,
+                                LocalDate patchDate){
+        this.patchNotePath=patchNotePath;
+        this.patchNoteTitle=patchNoteTitle;
+        this.patchDate=patchDate;
+    }
+}

--- a/src/main/java/soup/japopgg/crawlPatchNote/entity/PatchedAbility.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/entity/PatchedAbility.java
@@ -1,0 +1,39 @@
+package soup.japopgg.crawlPatchNote.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name="PatchedAbility")
+public class PatchedAbility {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String patchedAbility;
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String patchDetails;
+
+    //PatchedChampion와 다대일 양방향 매핑됨
+    //이 엔티티에서 PatchedChampion 참조
+    @ManyToOne
+    @JoinColumn(name="patchedChampion")
+    private PatchedChampion patchedChampion;
+
+    @Builder
+    public PatchedAbility(String patchedAbility, String patchDetails, PatchedChampion patchedChampion){
+        this.patchedAbility=patchedAbility;
+        this.patchDetails=patchDetails;
+        this.patchedChampion=patchedChampion;
+    }
+
+    public void updatePatchedAbility(String patchedAbility, String patchDetails, PatchedChampion patchedChampion){
+        this.patchedAbility=patchedAbility;
+        this.patchDetails=patchDetails;
+        this.patchedChampion=patchedChampion;
+    }
+}

--- a/src/main/java/soup/japopgg/crawlPatchNote/entity/PatchedChampion.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/entity/PatchedChampion.java
@@ -1,0 +1,51 @@
+package soup.japopgg.crawlPatchNote.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name="PatchedChampion")
+public class PatchedChampion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String champion;
+    @Column(nullable = false)
+    private String patchNoteTitle;
+    @Column(nullable = false)
+    private LocalDate patchDate;
+
+    //PatchedAbility와 다대일 양방향 매핑됨
+    //이 엔티티에서 FK 관리
+    @OneToMany(mappedBy = "patchedChampion", cascade = CascadeType.ALL)
+    private List<PatchedAbility> patchInfo;
+
+    @Builder
+    public PatchedChampion(String champion,
+                           String patchNoteTitle,
+                           LocalDate patchDate,
+                           List<PatchedAbility> patchInfo){
+        this.champion=champion;
+        this.patchNoteTitle=patchNoteTitle;
+        this.patchDate=patchDate;
+        this.patchInfo=patchInfo;
+    }
+
+    public void updatePatchedChampion(String champion,
+                                String patchNoteTitle,
+                                LocalDate patchDate,
+                                List<PatchedAbility> patchInfo){
+        this.champion=champion;
+        this.patchNoteTitle=patchNoteTitle;
+        this.patchDate=patchDate;
+        this.patchInfo=patchInfo;
+    }
+}

--- a/src/main/java/soup/japopgg/crawlPatchNote/repository/PatchNoteRepository.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/repository/PatchNoteRepository.java
@@ -1,0 +1,8 @@
+package soup.japopgg.crawlPatchNote.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import soup.japopgg.crawlPatchNote.entity.PatchNote;
+
+public interface PatchNoteRepository extends JpaRepository<PatchNote, Long> {
+    void deleteByPatchNoteTitle(String patchNoteTitle);
+}

--- a/src/main/java/soup/japopgg/crawlPatchNote/repository/PatchedAbilityRepository.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/repository/PatchedAbilityRepository.java
@@ -1,0 +1,7 @@
+package soup.japopgg.crawlPatchNote.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import soup.japopgg.crawlPatchNote.entity.PatchedAbility;
+
+public interface PatchedAbilityRepository extends JpaRepository<PatchedAbility,Long> {
+}

--- a/src/main/java/soup/japopgg/crawlPatchNote/repository/PatchedChampionRepository.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/repository/PatchedChampionRepository.java
@@ -1,0 +1,11 @@
+package soup.japopgg.crawlPatchNote.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import soup.japopgg.crawlPatchNote.entity.PatchedChampion;
+
+import java.util.List;
+
+public interface PatchedChampionRepository extends JpaRepository<PatchedChampion,Long> {
+    void deleteByPatchNoteTitleAndChampion(String patchNoteTitle,String champion);
+    List<PatchedChampion> findAllByPatchNoteTitle(String patchNoteTitle);
+}

--- a/src/main/java/soup/japopgg/crawlPatchNote/service/PatchDataService.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/service/PatchDataService.java
@@ -1,0 +1,67 @@
+package soup.japopgg.crawlPatchNote.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import soup.japopgg.crawlPatchNote.dto.PatchNoteDTO;
+import soup.japopgg.crawlPatchNote.dto.PatchedAbilityDTO;
+import soup.japopgg.crawlPatchNote.dto.PatchedChampionDTO;
+import soup.japopgg.crawlPatchNote.entity.PatchNote;
+import soup.japopgg.crawlPatchNote.entity.PatchedAbility;
+import soup.japopgg.crawlPatchNote.entity.PatchedChampion;
+import soup.japopgg.crawlPatchNote.repository.PatchNoteRepository;
+import soup.japopgg.crawlPatchNote.repository.PatchedChampionRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PatchDataService {
+
+    private final ObjectMapper objectMapper;
+    private final PatchNoteRepository patchNoteRepo;
+    private final PatchedChampionRepository patchedChampionRepo;
+
+    @Transactional
+    public void savePatchNoteData(PatchNoteDTO patchNoteDTO){
+        PatchNote patchNote=new PatchNote(patchNoteDTO.getPatchNotePath(),
+                patchNoteDTO.getPatchNoteTitle(),
+                patchNoteDTO.getPatchDate());
+
+        patchNoteRepo.save(patchNote);
+    }
+
+    @Transactional
+    public void savePatchedChampionData(PatchedChampionDTO patchedChampionDTO) throws JsonProcessingException {
+        PatchedChampion patchedChampion=new PatchedChampion(patchedChampionDTO.getChampion(),
+                patchedChampionDTO.getPatchNoteTitle(),
+                patchedChampionDTO.getPatchDate(),
+                new ArrayList<PatchedAbility>());
+
+        for(PatchedAbilityDTO patchedAbilityDTO:patchedChampionDTO.getPatchInfo()){
+            PatchedAbility patchedAbility=new PatchedAbility(
+                    patchedAbilityDTO.getPatchedAbility(),
+                    objectMapper.writeValueAsString(patchedAbilityDTO.getPatchDetails()),
+                    patchedChampion);
+            System.out.println(patchedAbility.getPatchDetails());
+            patchedChampion.getPatchInfo().add(patchedAbility);
+        }
+
+        patchedChampionRepo.save(patchedChampion);
+    }
+
+    @Transactional
+    public void deletePatchNoteData(String patchNoteTitle){
+        patchNoteRepo.deleteByPatchNoteTitle(patchNoteTitle);
+    }
+
+    @Transactional
+    public void deletePatchedChampionData(String patchNoteTitle,String champion){
+        patchedChampionRepo.deleteByPatchNoteTitleAndChampion(patchNoteTitle,champion);
+    }
+}

--- a/src/main/java/soup/japopgg/crawlPatchNote/service/SearchPatchService.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/service/SearchPatchService.java
@@ -1,0 +1,64 @@
+package soup.japopgg.crawlPatchNote.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import soup.japopgg.crawlPatchNote.dto.PatchNoteDTO;
+import soup.japopgg.crawlPatchNote.dto.PatchedAbilityDTO;
+import soup.japopgg.crawlPatchNote.dto.PatchedChampionDTO;
+import soup.japopgg.crawlPatchNote.entity.PatchNote;
+import soup.japopgg.crawlPatchNote.entity.PatchedChampion;
+import soup.japopgg.crawlPatchNote.repository.PatchNoteRepository;
+import soup.japopgg.crawlPatchNote.repository.PatchedChampionRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SearchPatchService {
+    private final ObjectMapper objectMapper;
+    private final PatchNoteRepository patchNoteRepo;
+    private final PatchedChampionRepository patchedChampionRepo;
+
+    public List<PatchNoteDTO> getPatchNoteList(){
+        List<PatchNote> patchNotes = patchNoteRepo.findAll();
+        List<PatchNoteDTO> result = patchNotes.stream()
+                .map(patchNote -> new PatchNoteDTO(
+                        patchNote.getPatchNotePath(),
+                        patchNote.getPatchNoteTitle(),
+                        patchNote.getPatchDate()
+                ))
+                .collect(Collectors.toList());
+
+        return result;
+    }
+
+    public List<PatchedChampionDTO> getPatchedChampionList(String patchNoteTitle){
+        List<PatchedChampion> patchedChampions = patchedChampionRepo.findAllByPatchNoteTitle(patchNoteTitle);
+        List<PatchedChampionDTO> result = patchedChampions.stream()
+                .map(champion -> new PatchedChampionDTO(
+                        champion.getChampion(),
+                        champion.getPatchNoteTitle(),
+                        champion.getPatchDate(),
+                        champion.getPatchInfo().stream()
+                                .map(patchedAbility -> {
+                                    try {
+                                        return new PatchedAbilityDTO(
+                                                patchedAbility.getPatchedAbility(),
+                                                objectMapper.readValue(patchedAbility.getPatchDetails(), List.class)
+                                        );
+                                    } catch (JsonProcessingException e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                })
+                                .collect(Collectors.toList())
+                ))
+                .collect(Collectors.toList());
+
+        return result;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,10 @@
 spring.application.name=japop-gg
 
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+spring.jpa.properties.hibernate.dialect= org.hibernate.dialect.MySQLDialect
+spring.datasource.url=jdbc:mysql://localhost:3306/JapopGG?serverTimezone=Asia/Seoul
+spring.datasource.username=root
+spring.datasource.password=
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=update
 
 spring.config.import=classpath:patchNoteUrl.yml


### PR DESCRIPTION
패치노트 및 해당 패치노트에 명시된 챔피언과 변경사항 데이터를 저장하고 관리하는 기능입니다.
챔피언 스킬의 세부 변경사항의 경우, ObjectMapper를 통해 문자열 배열을 하나의 문자열로 관리하도록 했습니다.
패치된 스킬과 패치된 챔피언 데이터는 다대일 양방향 관계를 가지도록 했습니다.