### PR TITLE
FEAT : 패치노트 자동 업데이트 및 데이터 캐싱 추가

### DIFF
--- a/src/main/java/soup/japopgg/crawlPatchNote/component/PatchNoteScheduler.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/component/PatchNoteScheduler.java
@@ -1,0 +1,33 @@
+package soup.japopgg.crawlPatchNote.component;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import soup.japopgg.crawlPatchNote.dto.PatchNoteDTO;
+import soup.japopgg.crawlPatchNote.dto.PatchedChampionDTO;
+import soup.japopgg.crawlPatchNote.service.CrawlingService;
+import soup.japopgg.crawlPatchNote.service.PatchDataService;
+import soup.japopgg.crawlPatchNote.service.SearchPatchService;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PatchNoteScheduler {
+    private final CrawlingService crawlingService;
+    private final PatchDataService patchDataService;
+    private final SearchPatchService searchPatchService;
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void updatePatchNote() throws IOException {
+        PatchNoteDTO crawledDTO = crawlingService.crawlLatestPatchNoteTitle();
+        PatchNoteDTO latestPatchNoteDTOInDatabase = searchPatchService.getCurrentPatchNote();
+        if(!crawledDTO.getPatchNoteTitle().equals(latestPatchNoteDTOInDatabase.getPatchNoteTitle())){
+            List<PatchedChampionDTO> patchList = crawlingService.crawlPatchNote(
+                    crawledDTO.getPatchNotePath(),crawledDTO.getPatchNoteTitle(),crawledDTO.getPatchDate());
+            for(PatchedChampionDTO patchData:patchList)
+                patchDataService.savePatchedChampionData(patchData);
+        }
+    }
+}

--- a/src/main/java/soup/japopgg/crawlPatchNote/controller/PatchNoteController.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/controller/PatchNoteController.java
@@ -1,0 +1,32 @@
+package soup.japopgg.crawlPatchNote.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import soup.japopgg.crawlPatchNote.dto.PatchNoteDTO;
+import soup.japopgg.crawlPatchNote.dto.PatchedChampionDTO;
+import soup.japopgg.crawlPatchNote.service.SearchPatchService;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class PatchNoteController {
+    private final SearchPatchService searchPatchService;
+
+    @GetMapping("/getPatchNoteList")
+    public List<PatchNoteDTO> patchNoteList(){
+        return searchPatchService.getPatchNoteList();
+    }
+
+    @GetMapping("/getPatchNote")
+    public List<PatchedChampionDTO> patchNoteInfo(@RequestParam String patchNoteName){
+        return searchPatchService.getPatchedChampionList(patchNoteName);
+    }
+
+    @GetMapping("/getChampionPatchHistory")
+    public List<PatchedChampionDTO> championPatchHistory(@RequestParam String championName){
+        return searchPatchService.getChampionPatchHistory(championName);
+    }
+}

--- a/src/main/java/soup/japopgg/crawlPatchNote/repository/PatchNoteRepository.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/repository/PatchNoteRepository.java
@@ -7,5 +7,6 @@ import java.util.List;
 
 public interface PatchNoteRepository extends JpaRepository<PatchNote, Long> {
     void deleteByPatchNoteTitle(String patchNoteTitle);
-    List<PatchNote> findAllOrderByPatchDateDesc();
+    List<PatchNote> findAllByOrderByPatchDateDesc();
+    PatchNote findFirstByOrderByPatchDateDesc();
 }

--- a/src/main/java/soup/japopgg/crawlPatchNote/repository/PatchNoteRepository.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/repository/PatchNoteRepository.java
@@ -3,6 +3,9 @@ package soup.japopgg.crawlPatchNote.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import soup.japopgg.crawlPatchNote.entity.PatchNote;
 
+import java.util.List;
+
 public interface PatchNoteRepository extends JpaRepository<PatchNote, Long> {
     void deleteByPatchNoteTitle(String patchNoteTitle);
+    List<PatchNote> findAllOrderByPatchDateDesc();
 }

--- a/src/main/java/soup/japopgg/crawlPatchNote/repository/PatchedChampionRepository.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/repository/PatchedChampionRepository.java
@@ -7,5 +7,6 @@ import java.util.List;
 
 public interface PatchedChampionRepository extends JpaRepository<PatchedChampion,Long> {
     void deleteByPatchNoteTitleAndChampion(String patchNoteTitle,String champion);
-    List<PatchedChampion> findAllByPatchNoteTitle(String patchNoteTitle);
+    List<PatchedChampion> findAllByPatchNoteTitleOrderByChampionDesc(String patchNoteTitle);
+    List<PatchedChampion> findAllByChampionOrderByPatchDateDesc(String championName);
 }

--- a/src/main/java/soup/japopgg/crawlPatchNote/service/CrawlingService.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/service/CrawlingService.java
@@ -25,7 +25,7 @@ public class CrawlingService {
 
     private final CrawlConfig crawlConfig;
 
-    public PatchNoteDTO crawlLatestPatchNoteTitle()throws IOException {
+    public PatchNoteDTO crawlLatestPatchNoteTitle() throws IOException {
         String patchNoteListUrl = crawlConfig.getPath().getBaseUrl() + crawlConfig.getPath().getListPath();
 
         Document document = Jsoup.connect(patchNoteListUrl).get();

--- a/src/main/java/soup/japopgg/crawlPatchNote/service/PatchDataService.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/service/PatchDataService.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import soup.japopgg.crawlPatchNote.dto.PatchNoteDTO;
@@ -27,6 +29,7 @@ public class PatchDataService {
     private final PatchNoteRepository patchNoteRepo;
     private final PatchedChampionRepository patchedChampionRepo;
 
+    @CacheEvict(value = "patchNoteList", allEntries = true)
     @Transactional
     public void savePatchNoteData(PatchNoteDTO patchNoteDTO){
         PatchNote patchNote=new PatchNote(patchNoteDTO.getPatchNotePath(),
@@ -36,6 +39,7 @@ public class PatchDataService {
         patchNoteRepo.save(patchNote);
     }
 
+    @CacheEvict(value = "championPatchHistory", key = "#patchedChampionDTO.champion")
     @Transactional
     public void savePatchedChampionData(PatchedChampionDTO patchedChampionDTO) throws JsonProcessingException {
         PatchedChampion patchedChampion=new PatchedChampion(patchedChampionDTO.getChampion(),
@@ -55,11 +59,19 @@ public class PatchDataService {
         patchedChampionRepo.save(patchedChampion);
     }
 
+    @Caching(evict = {
+            @CacheEvict(value = "patchNoteList", allEntries = true),
+            @CacheEvict(value = "patchedChampionList", key = "#patchNoteTitle")
+    })
     @Transactional
     public void deletePatchNoteData(String patchNoteTitle){
         patchNoteRepo.deleteByPatchNoteTitle(patchNoteTitle);
     }
 
+    @Caching(evict = {
+            @CacheEvict(value = "championPatchHistory", key = "#champion"),
+            @CacheEvict(value = "patchedChampionList", key = "#patchNoteTitle")
+    })
     @Transactional
     public void deletePatchedChampionData(String patchNoteTitle,String champion){
         patchedChampionRepo.deleteByPatchNoteTitleAndChampion(patchNoteTitle,champion);

--- a/src/main/java/soup/japopgg/crawlPatchNote/service/SearchPatchService.java
+++ b/src/main/java/soup/japopgg/crawlPatchNote/service/SearchPatchService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import soup.japopgg.crawlPatchNote.dto.PatchNoteDTO;
 import soup.japopgg.crawlPatchNote.dto.PatchedAbilityDTO;
 import soup.japopgg.crawlPatchNote.dto.PatchedChampionDTO;
@@ -24,8 +25,9 @@ public class SearchPatchService {
     private final PatchNoteRepository patchNoteRepo;
     private final PatchedChampionRepository patchedChampionRepo;
 
+    @Transactional(readOnly = true)
     public List<PatchNoteDTO> getPatchNoteList(){
-        List<PatchNote> patchNotes = patchNoteRepo.findAll();
+        List<PatchNote> patchNotes = patchNoteRepo.findAllOrderByPatchDateDesc();
         List<PatchNoteDTO> result = patchNotes.stream()
                 .map(patchNote -> new PatchNoteDTO(
                         patchNote.getPatchNotePath(),
@@ -37,8 +39,19 @@ public class SearchPatchService {
         return result;
     }
 
+    @Transactional(readOnly = true)
     public List<PatchedChampionDTO> getPatchedChampionList(String patchNoteTitle){
-        List<PatchedChampion> patchedChampions = patchedChampionRepo.findAllByPatchNoteTitle(patchNoteTitle);
+        List<PatchedChampion> patchedChampions = patchedChampionRepo.findAllByPatchNoteTitleOrderByChampionDesc(patchNoteTitle);
+        return convertPatchedChampionEntityToDto(patchedChampions);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PatchedChampionDTO> getChampionPatchHistory(String championName){
+        List<PatchedChampion> patchedChampions = patchedChampionRepo.findAllByChampionOrderByPatchDateDesc(championName);
+        return convertPatchedChampionEntityToDto(patchedChampions);
+    }
+
+    private List<PatchedChampionDTO> convertPatchedChampionEntityToDto(List<PatchedChampion> patchedChampions){
         List<PatchedChampionDTO> result = patchedChampions.stream()
                 .map(champion -> new PatchedChampionDTO(
                         champion.getChampion(),

--- a/src/test/java/soup/japopgg/JapopGgApplicationTests.java
+++ b/src/test/java/soup/japopgg/JapopGgApplicationTests.java
@@ -7,14 +7,21 @@ import soup.japopgg.crawlPatchNote.dto.PatchNoteDTO;
 import soup.japopgg.crawlPatchNote.dto.PatchedAbilityDTO;
 import soup.japopgg.crawlPatchNote.dto.PatchedChampionDTO;
 import soup.japopgg.crawlPatchNote.service.CrawlingService;
+import soup.japopgg.crawlPatchNote.service.PatchDataService;
+import soup.japopgg.crawlPatchNote.service.SearchPatchService;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.List;
 
 @SpringBootTest
 class JapopGgApplicationTests {
 	@Autowired
 	CrawlingService crawlingService;
+	@Autowired
+	PatchDataService patchDataService;
+	@Autowired
+	SearchPatchService searchPatchService;
 
 	@Test
 	void parsePatchNoteListTest() throws IOException {
@@ -28,7 +35,9 @@ class JapopGgApplicationTests {
 	void parsePatchNoteTest() throws IOException{
 		String testPath = "ko-kr/news/game-updates/patch-14-9-notes/";
 		String testTitle = "14.10 패치노트";
-		List<PatchedChampionDTO> testList = crawlingService.crawlPatchNote(testPath,testTitle);
+		LocalDate testDate = LocalDate.now();
+
+		List<PatchedChampionDTO> testList = crawlingService.crawlPatchNote(testPath,testTitle,testDate);
 		for(PatchedChampionDTO champ: testList){
 			System.out.println(champ.getPatchNoteTitle());
 			System.out.println(champ.getChampion());
@@ -38,5 +47,40 @@ class JapopGgApplicationTests {
 					System.out.println("\t"+detail);
 			}
 		}
+	}
+
+	@Test
+	void savePatchNoteTest() throws IOException{
+		String testPath = "ko-kr/news/game-updates/patch-14-9-notes/";
+		String testTitle = "14.10 패치노트";
+		LocalDate testDate = LocalDate.now();
+
+		patchDataService.savePatchNoteData(new PatchNoteDTO(testPath,testTitle,testDate));
+		List<PatchNoteDTO> testList = searchPatchService.getPatchNoteList();
+		for(PatchNoteDTO result:testList)
+			System.out.println(result.getPatchNoteTitle());
+	}
+
+	@Test
+	void deletePatchNoteTest() throws IOException{
+		String testTitle = "14.10 패치노트";
+		patchDataService.deletePatchNoteData(testTitle);
+	}
+
+	@Test
+	void saveChampionPatchTest() throws IOException{
+		String testPath = "ko-kr/news/game-updates/patch-14-9-notes/";
+		String testTitle = "14.10 패치노트";
+		LocalDate testDate = LocalDate.now();
+
+		List<PatchedChampionDTO> testList = crawlingService.crawlPatchNote(testPath,testTitle,testDate);
+		for(PatchedChampionDTO champ: testList)
+			patchDataService.savePatchedChampionData(champ);
+	}
+
+	@Test
+	void deleteChampionPatchTest() throws IOException{
+		String testTitle = "14.10 패치노트";
+		patchDataService.deletePatchedChampionData(testTitle,"아크샨");
 	}
 }


### PR DESCRIPTION
매일 0시마다 리그 오브 레전드 패치노트 목록을 크롤링합니다.
크롤링 결과의 최신 패치노트와, 자팝지지 데이터베이스 내의 최신 패치노트 정보를 비교하여 업데이트를 진행합니다.

패치노트 데이터를 검색할 경우, 해당 데이터를 캐싱합니다.
같은 데이터에 대해 중복 검색할 경우, 데이터베이스를 조회하지 않고 캐싱해 둔 데이터를 반환합니다.
패치노트 업데이트가 진행될 경우, 그에 따른 캐시 데이터를 삭제합니다.